### PR TITLE
Support configurable producer config name for each producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ``
 ## UNRELEASED
 
+- Support configurable producer config key for producers
+
 ## [2.1.0] - 2021-05-27
 
 - Modify config to allow specifying kafka connection information separately for consumers and producers
@@ -47,7 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   messages and batches.
 
 ## [1.8.3-beta1] - 2019-11-11
-- Automatically heartbeat after every message if necessary in batch 
+- Automatically heartbeat after every message if necessary in batch
   mode.
 
 ## [1.8.2] - 2019-11-11

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -62,8 +62,8 @@ module Phobos
         class_variable_get :@@producer_config
       end
 
-      def config_producer_config(config)
-        class_variable_set :@@producer_config, config
+      def configure_producer(producer)
+        class_variable_set :@@producer_config, producer
       end
 
       class PublicAPI

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -4,6 +4,7 @@ module Phobos
   module Producer
     def self.included(base)
       base.extend(Phobos::Producer::ClassMethods)
+      base.class_variable_set(:@@producer_config, :producer)
     end
 
     def producer
@@ -54,13 +55,25 @@ module Phobos
 
     module ClassMethods
       def producer
-        Phobos::Producer::ClassMethods::PublicAPI.new
+        Phobos::Producer::ClassMethods::PublicAPI.new(self)
+      end
+
+      def producer_config
+        self.class_variable_get :@@producer_config
+      end
+
+      def config_producer_config(config)
+        self.class_variable_set :@@producer_config, config
       end
 
       class PublicAPI
         NAMESPACE = :phobos_producer_store
         ASYNC_PRODUCER_PARAMS = [:max_queue_size, :delivery_threshold, :delivery_interval].freeze
         INTERNAL_PRODUCER_PARAMS = [:persistent_connections].freeze
+
+        def initialize(host_obj = nil)
+          @host_obj = host_obj
+        end
 
         # This method configures the kafka client used with publish operations
         # performed by the host class
@@ -77,7 +90,7 @@ module Phobos
         end
 
         def create_sync_producer
-          client = kafka_client || configure_kafka_client(Phobos.create_kafka_client(:producer))
+          client = kafka_client || configure_kafka_client(create_kafka_client)
           sync_producer = client.producer(**regular_configs)
           if Phobos.config.producer_hash[:persistent_connections]
             producer_store[:sync_producer] = sync_producer
@@ -108,7 +121,7 @@ module Phobos
         end
 
         def create_async_producer
-          client = kafka_client || configure_kafka_client(Phobos.create_kafka_client(:producer))
+          client = kafka_client || configure_kafka_client(create_kafka_client)
           async_producer = client.async_producer(**async_configs)
           producer_store[:async_producer] = async_producer
         end
@@ -147,6 +160,10 @@ module Phobos
 
         private
 
+        def create_kafka_client
+          Phobos.create_kafka_client(@host_obj.producer_config)
+        end
+
         def produce_messages(producer, messages)
           messages.each do |message|
             partition_key = message[:partition_key] || message[:key]
@@ -164,6 +181,9 @@ module Phobos
 
         def producer_store
           Thread.current[NAMESPACE] ||= {}
+          if @host_obj.producer_config
+            Thread.current[NAMESPACE][@host_obj.producer_config] ||= {}
+          end
         end
       end
     end

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -59,11 +59,11 @@ module Phobos
       end
 
       def producer_config
-        self.class_variable_get :@@producer_config
+        class_variable_get :@@producer_config
       end
 
       def config_producer_config(config)
-        self.class_variable_set :@@producer_config, config
+        class_variable_set :@@producer_config, config
       end
 
       class PublicAPI
@@ -71,8 +71,8 @@ module Phobos
         ASYNC_PRODUCER_PARAMS = [:max_queue_size, :delivery_threshold, :delivery_interval].freeze
         INTERNAL_PRODUCER_PARAMS = [:persistent_connections].freeze
 
-        def initialize(host_obj = nil)
-          @host_obj = host_obj
+        def initialize(host_class)
+          @host_class = host_class
         end
 
         # This method configures the kafka client used with publish operations
@@ -161,7 +161,7 @@ module Phobos
         private
 
         def create_kafka_client
-          Phobos.create_kafka_client(@host_obj.producer_config)
+          Phobos.create_kafka_client(@host_class.producer_config)
         end
 
         def produce_messages(producer, messages)
@@ -181,8 +181,10 @@ module Phobos
 
         def producer_store
           Thread.current[NAMESPACE] ||= {}
-          if @host_obj.producer_config
-            Thread.current[NAMESPACE][@host_obj.producer_config] ||= {}
+          if @host_class.producer_config
+            Thread.current[NAMESPACE][@host_class.producer_config] ||= {}
+          else
+            Thread.current[NAMESPACE]
           end
         end
       end

--- a/spec/lib/phobos/listener_spec.rb
+++ b/spec/lib/phobos/listener_spec.rb
@@ -430,7 +430,7 @@ RSpec.describe Phobos::Listener do
 
   describe 'when the handler includes the producer module' do
     let(:handler_class) { TestListenerHandlerWithProducer }
-    let(:producer_api) { Phobos::Producer::ClassMethods::PublicAPI.new }
+    let(:producer_api) { Phobos::Producer::ClassMethods::PublicAPI.new(handler_class) }
 
     before do
       allow(TestListenerHandlerWithProducer)

--- a/spec/lib/phobos/producer_spec.rb
+++ b/spec/lib/phobos/producer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Phobos::Producer do
   after { TestProducer1.producer.configure_kafka_client(nil) }
   subject { TestProducer1.new }
   let(:internal_params) { Phobos::Producer::ClassMethods::PublicAPI::INTERNAL_PRODUCER_PARAMS }
-  let(:public_api) { Phobos::Producer::ClassMethods::PublicAPI.new }
+  let(:public_api) { Phobos::Producer::ClassMethods::PublicAPI.new(TestProducer1) }
 
   describe '#publish' do
     it 'publishes a single message using "publish_list"' do


### PR DESCRIPTION
## How to use 

```ruby
class TestProducer1
  include Phobos::Producer
  configure_producer :another_producer
end
```

And have `another_producer` section in `phobos.yaml` file.