### PR TITLE
change string to hash

### DIFF
--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -128,7 +128,7 @@ module Phobos
         log_info('Listener stopped', listener_metadata) if should_stop?
       end
     rescue NoMethodError => e
-      log_error('Listener stop failed', e)
+      log_error('Listener stop failed', { error: e.to_s })
     end
 
     def start_consumer_loop


### PR DESCRIPTION
```
[2022-05-30T03:32:04:947+0000Z] ERROR -- Phobos : <Hash> {:message=>"Listener crashed
 waiting 48.32s (no implicit conversion of NoMethodError into Hash)"
 :listener_id=>"18507e"
 :retry_count=>1133
 :waiting_time=>48.32
 :exception_class=>"TypeError"
 :exception_message=>"no implicit conversion of NoMethodError into Hash"
 :backtrace=>["/usr/local/bundle/gems/phobos-3.0.3/lib/phobos/log.rb:20:in `merge'"
 "/usr/local/bundle/gems/phobos-3.0.3/lib/phobos/log.rb:20:in `log'"
 "/usr/local/bundle/gems/phobos-3.0.3/lib/phobos/log.rb:14:in `log_error'"
 "/usr/local/bundle/gems/phobos-3.0.3/lib/phobos/listener.rb:131:in `rescue in stop_listener'"
 "/usr/local/bundle/gems/phobos-3.0.3/lib/phobos/listener.rb:116:in `stop_listener'"
 "/usr/local/bundle/gems/phobos-3.0.3/lib/phobos/listener.rb:60:in `ensure in start'"
 "/usr/local/bundle/gems/phobos-3.0.3/lib/phobos/listener.rb:60:in `start'"
 "/usr/local/bundle/gems/phobos-3.0.3/lib/phobos/executor.rb:72:in `run_listener'"
 "/usr/local/bundle/gems/phobos-3.0.3/lib/phobos/executor.rb:31:in `block (2 levels) in start'"
 "/usr/local/bundle/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:363:in `run_task'"
 "/usr/local/bundle/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:352:in `block (3 levels) in create_worker'"
 "/usr/local/bundle/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `loop'"
 "/usr/local/bundle/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `block (2 levels) in create_worker'"
 "/usr/local/bundle/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `catch'"
 "/usr/local/bundle/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `block in create_worker'"
 "/usr/local/bundle/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'"]}
```